### PR TITLE
Fixed swapped latitude/longitude for cankiri

### DIFF
--- a/cities.json
+++ b/cities.json
@@ -355,8 +355,8 @@
   {
     "name": "çankırı",
     "plate": "18",
-    "latitude": "33.58838",
-    "longitude": "40.53690",
+    "latitude": "40.53690",
+    "longitude": "33.58838",
     "counties": [
       "merkez",
       "çerkeş",

--- a/cities.json
+++ b/cities.json
@@ -592,8 +592,8 @@
   {
     "name": "gümüşhane",
     "plate": "29",
-    "latitude": "39.31432",
-    "longitude": "40.28036",
+    "latitude": "40.28036",
+    "longitude": "39.31432",
     "counties": [
       "merkez",
       "kelkit",


### PR DESCRIPTION
The cause of the error is lat/long are entered manually by hand, maybe.